### PR TITLE
upgrade to xunit 2.3.1 and xbehave 2.3.0-rc0001-build717

### DIFF
--- a/s/tests/CoreUnitTests/CoreUnitTests.csproj
+++ b/s/tests/CoreUnitTests/CoreUnitTests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>
 
 </Project>

--- a/s/tests/Spec/Spec.csproj
+++ b/s/tests/Spec/Spec.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -47,23 +48,23 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Xbehave.Core, Version=2.1.4.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xbehave.Core.2.1.4\lib\portable-net45\Xbehave.Core.dll</HintPath>
+    <Reference Include="Xbehave.Core, Version=2.3.0.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Xbehave.Core.2.3.0-rc0001-build717\lib\net452\Xbehave.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Xbehave.Execution.desktop, Version=2.1.4.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xbehave.Core.2.1.4\lib\portable-net45\Xbehave.Execution.desktop.dll</HintPath>
+    <Reference Include="Xbehave.Execution.desktop, Version=2.3.0.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Xbehave.Core.2.3.0-rc0001-build717\lib\net452\Xbehave.Execution.desktop.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.3.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.3.1\lib\netstandard1.1\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.3.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -72,6 +73,7 @@
     <Compile Include="Stubs\StringAuditLogger.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -80,5 +82,16 @@
       <Name>AuditTree.Core</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" />
 </Project>

--- a/s/tests/Spec/app.config
+++ b/s/tests/Spec/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.1.3858" newVersion="2.3.1.3858" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.1.3858" newVersion="2.3.1.3858" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/s/tests/Spec/packages.config
+++ b/s/tests/Spec/packages.config
@@ -2,12 +2,13 @@
 <packages>
   <package id="FluentAssertions" version="4.19.4" targetFramework="net462" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net462" />
-  <package id="Xbehave" version="2.1.4" targetFramework="net462" />
-  <package id="Xbehave.Core" version="2.1.4" targetFramework="net462" />
-  <package id="xunit" version="2.1.0" targetFramework="net462" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net462" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net462" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net462" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net462" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net462" />
+  <package id="Xbehave" version="2.3.0-rc0001-build717" targetFramework="net462" />
+  <package id="Xbehave.Core" version="2.3.0-rc0001-build717" targetFramework="net462" />
+  <package id="xunit" version="2.3.1" targetFramework="net462" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net462" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net462" />
+  <package id="xunit.assert" version="2.3.1" targetFramework="net462" />
+  <package id="xunit.core" version="2.3.1" targetFramework="net462" />
+  <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net462" />
+  <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Some background: before releasing xbehave 2.3.0 RTM, I'm attempting to find projects who would be willing to test the release candidate. This PR upgrades xbehave to 2.3.0-rc0001 (which also requires an upgrade to the latest xunit, which is 2.3.1).

I tested everything locally and the tests pass. Note that an xbehave RC is a _true RC_. I.e. it is RTM quality and if no bugs are found, 2.3.0 RTM will be released with a build from the same source code as the latest 2.3.0 RC. Therefore the risk of using an RC (which is, after all, still a pre-release) should be very low, but of course, it's up to you whether you want to merge this PR. 😉

Regardless, thanks for using xbehave, I hope you're enjoying it. 👍 